### PR TITLE
Fix typings module name for ES6 imports

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -9,7 +9,7 @@ declare enum ChannelType {
   unknown = 7,
 }
 
-declare module 'discord.js' {
+declare module 'discord.js-selfbot' {
   import BaseCollection from '@discordjs/collection';
   import { EventEmitter } from 'events';
   import { Stream, Readable, Writable } from 'stream';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Rename the module name in the typings file to match package name. Previous to this, one of two scenarios would occur, preventing use of ES6 import syntax:
- "File <path> is not a module." for module name 'discord.js-selfbot'
- "Cannot find module 'discord.js' or its corresponding type declarations." for module name 'discord.js' (current name)

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
- [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
